### PR TITLE
Add hostname binary to proxy-init image

### DIFF
--- a/Dockerfile.proxy-init
+++ b/Dockerfile.proxy-init
@@ -14,7 +14,7 @@ ENV container="oci"
 ENV ISTIO_VERSION=1.1.5
 
 RUN microdnf update -y && \
-    microdnf install -y iptables iproute && \
+    microdnf install -y iptables iproute hostname && \
     microdnf clean all
 
 WORKDIR /tmp/


### PR DESCRIPTION
The hostname binary isn't included in ubi-minimal, causing a failure in istio-iptables.sh