### PR TITLE
[Maistra-2008] Check for istiod instead of pilot

### DIFF
--- a/artifacts/gather_istio
+++ b/artifacts/gather_istio
@@ -56,11 +56,15 @@ function getMembers() {
   local cp="${1}"
 
   local output="$(oc -n "${cp}" get ServiceMeshMemberRoll default -o jsonpath='{..members}' 2>/dev/null)"
+
   if [ -z "${output}" ]; then
     return
   fi
 
   output="$(echo ${output} | tr '[]' '  ')"
+
+  # The oc get command above returns namespaces surrounded by quotes. Trim any quotes.
+  output=$(echo ${output} | sed -e 's/"//g')
   echo ${output}
 }
 
@@ -91,7 +95,7 @@ function getSynchronization() {
   local namespace="${1}"
 
   echo "Collecting resources for namespace ${cp}"
-  local pilotName=$(oc get pods -n ${namespace} -lapp=pilot  -o jsonpath="{.items[0].metadata.name}")
+  local pilotName=$(oc get pods -n ${namespace} -lapp=istiod  -o jsonpath="{.items[0].metadata.name}")
 
   echo "Overall Envoy synchronization status for namespace ${namespace}" 2>&1 1>${logPath}/controlPlaneStatus
   local logPath=${BASE_COLLECTION_PATH}/namespaces/${namespace}/controlplane
@@ -108,20 +112,24 @@ function getSynchronization() {
 #   nothing
 function getEnvoyConfigForPodsInNamespace() {
   local controlPlaneNamespace="${1}"
-  local pilotName=$(oc get pods -n ${controlPlaneNamespace} -lapp=pilot  -o jsonpath="{.items[0].metadata.name}")
+  local pilotName=$(oc get pods -n ${controlPlaneNamespace} -lapp=istiod  -o jsonpath="{.items[0].metadata.name}")
   local podNamespace="${2}"
 
   echo "Collecting Envoy config for pods in ${podNamespace}, control plane namespace ${controlPlaneNamespace}"
 
   local pods="$(oc get pods -n ${podNamespace} -o jsonpath='{ .items[*].metadata.name }')"
   for podName in ${pods}; do
+    if [ -z $podName ]; then
+        continue
+    fi
+
     if oc get pod -o yaml ${podName} -n ${podNamespace} | grep -q proxyv2; then
       echo "Collecting config for pod ${podName}.${podNamespace}"
 
       local logPath=${BASE_COLLECTION_PATH}/namespaces/${podNamespace}/pods/${podName}
       mkdir -p ${logPath}
 
-      echo "Pilot config for pod ${podName}.${podNamespace} from pilot ${pilotName}.${controlPlaneNamespace}" 2>&1 1>${logPath}/pilotConfiguration
+      echo "Pilot config for pod ${podName}.${podNamespace} from istiod ${pilotName}.${controlPlaneNamespace}" 2>&1 1>${logPath}/pilotConfiguration
       oc exec ${pilotName} -n ${controlPlaneNamespace} -c discovery -- bash -c "/usr/local/bin/pilot-discovery request GET /debug/config_dump?proxyID=${podName}.${podNamespace}" 2>&1 1>${logPath}/pilotConfiguration
 
       echo "Envoy config for pod ${podName}.${podNamespace} from pilot ${pilotName}.${controlPlaneNamespace}" 2>&1 1>${logPath}/envoyConfiguration
@@ -143,16 +151,20 @@ function main() {
   resources+="$(addResourcePrefix ns ${controlPlanes})"
 
   for cp in ${controlPlanes}; do
-    local members=$(getMembers ${cp})
+      local members=$(getMembers ${cp})
       resources+="$(addResourcePrefix ns ${members})"
       getSynchronization ${cp}
+
       for cr in ${DEPENDENCY_CRS}; do
-        oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" ${resource}
+        oc adm inspect "--dest-dir=${BASE_COLLECTION_PATH}" -n ${cp} ${cr}
       done
 
        #collect Envoy configuration first from control plane pods and then from members
        getEnvoyConfigForPodsInNamespace ${cp} ${cp}
        for member in ${members}; do
+           if [ -z $member ]; then
+               continue
+           fi
           echo "Processing ${cp} member ${member}"
           getEnvoyConfigForPodsInNamespace ${cp} ${member}
        done


### PR DESCRIPTION
This fixes a couple of different errors seen while testing must-gather. 

* Empty SMMRs cause errors while trying to iterate over null
* Pilot was renamed to istiod, so references to Pilot were failing
* The namespaces now return wrapped in quotes. Must-gather fails processing them: 
```
ust-gather-7kzb4] POD + oc adm inspect --dest-dir=/must-gather 'ns/"bookinfo"'
[must-gather-7kzb4] POD Error from server (NotFound): namespaces "\"bookinfo\"" not found
```